### PR TITLE
Update README to point to the project's website instead of the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Juno is an environment for the Julia language, with strong support for interactive development and a whole load of other niceties, implemented over Light Table.
 
-Please see [the wiki](https://github.com/one-more-minute/Juno-LT/wiki) for installation instructions and documentation, and the [Julia-LT](https://github.com/one-more-minute/Julia-LT/issues) repo for issues.
+More info at [junolab.org](http://junolab.org)
+
+Please see [the website](http://junolab.org/docs/installing.html) for installation instructions and documentation, and the [Julia-LT](https://github.com/one-more-minute/Julia-LT/issues) repo for issues.
 
 Note that the [Julia language plugin](https://github.com/one-more-minute/Julia-LT) provides the core functionailty; this repo is essentially a thin wrapper which exposes that functionality and provides a more convenient set of defaults.
 


### PR DESCRIPTION
I wasn't aware of the website until the presentation at the Julia meet up. I think the README should point there and the wiki should be deprecated.
